### PR TITLE
Fix some `brew audit` errors

### DIFF
--- a/Formula/hck.rb
+++ b/Formula/hck.rb
@@ -2,18 +2,18 @@
 #                https://rubydoc.brew.sh/Formula
 # PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
 class Hck < Formula
-    version "v0.4.2"
-    desc "A faster and more featureful clone of cut."
+    version "0.4.2"
+    desc "Faster and more featureful clone of cut"
     homepage "https://github.com/sstadick/hck"
-    license any_of: ["MIT", "UNLICENSE"]
+    license any_of: ["MIT", "Unlicense"]
 
     if OS.linux?
         # wget -q -S -O - https://github.com/sstadick/hck/releases/download/v0.4.2/hck-linux-amd64 | shasum -a 256
-        url "https://github.com/sstadick/hck/releases/download/#{version}/hck-linux-amd64"
+        url "https://github.com/sstadick/hck/releases/download/v#{version}/hck-linux-amd64"
         sha256 "e2a4be8eef3568af9a6b7b780d1a15a80617121b3973cba763345ee4ec8b6016"
     elsif OS.mac?
         # wget -q -S -O - https://github.com/sstadick/hck/releases/download/v0.4.2/hck-macos-amd64 | shasum -a 256
-        url "https://github.com/sstadick/hck/releases/download/#{version}/hck-macos-amd64"
+        url "https://github.com/sstadick/hck/releases/download/v#{version}/hck-macos-amd64"
         sha256 "fa5af7e5db08164ced8309fb137a4cc0a3bc5770388591323ddc2c84582c9578"
     end
 
@@ -28,4 +28,4 @@ class Hck < Formula
     #   system "bash", "pgo_local.sh"
     #   bin.install "target/release/hck"
     # end
-  end
+end


### PR DESCRIPTION
* [x] **Error:** Formula hck contains non-standard SPDX licenses: ["UNLICENSE"].
    * **Solution:** Replace `UNLICENSE` with `Unlicense`. (Note the different capitalization)
* [x] **Error:** version v0.4.2 should not have a leading 'v'
    * **Solution:** put the `v` in `url` instead of `version`.
* [x] **Error:** Description shouldn't start with an article.
    * **Solution:** delete the word `A`.
* [x] **Error:** Description shouldn't end with a full stop.
    * **Solution:** delete the period (a.k.a. full stop).
* [x] **Error:** `end` at 31, 2 is not aligned with `class Hck < Formula` at 4, 0.
    * **Solution:** de-indent the `end` at the bottom of the file.
* [x] **Error:** Final newline missing.
    * **Solution:** add a newline at the end of the file.