### PR TITLE
Correct version number  by .1

### DIFF
--- a/Formula/hck.rb
+++ b/Formula/hck.rb
@@ -2,7 +2,7 @@ class Hck < Formula
   desc "Faster and more featureful clone of cut"
   homepage "https://github.com/sstadick/hck"
   license any_of: ["MIT", "Unlicense"]
-  version "0.6.0"
+  version "0.6.1"
 
   if OS.linux?
     # wget -q -S -O - https://github.com/sstadick/hck/releases/download/v0.6.1/hck-linux-amd64 | shasum -a 256


### PR DESCRIPTION
I literally just ran into this when updating randomly, can't believe it's only been 5 minutes since the change lol.